### PR TITLE
fix: Firestoreエミュレータ権限エラーを解決

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test: test-backend test-frontend ## 全テストを実行
 
 .PHONY: test-backend
 test-backend: ## バックエンドのテストを実行
-	cd backend && go test -v ./...
+	cd backend && FIRESTORE_EMULATOR_HOST=localhost:8081 go test -v ./...
 
 .PHONY: test-frontend
 test-frontend: ## フロントエンドのテストを実行
@@ -49,6 +49,14 @@ test-frontend: ## フロントエンドのテストを実行
 
 .PHONY: test-all
 test-all: test ## 全テストを実行（エイリアス）
+
+.PHONY: test-backend-unit
+test-backend-unit: ## バックエンドの単体テストのみ実行
+	cd backend && FIRESTORE_EMULATOR_HOST=localhost:8081 go test -v ./internal/handlers/... ./internal/domain/...
+
+.PHONY: test-backend-integration
+test-backend-integration: ## バックエンドの統合テストのみ実行
+	cd backend && FIRESTORE_EMULATOR_HOST=localhost:8081 go test -v ./internal/infrastructure/... ./internal/routes/...
 
 # Lint関連
 .PHONY: lint

--- a/backend/internal/infrastructure/repository/schedule_test.go
+++ b/backend/internal/infrastructure/repository/schedule_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -20,7 +21,18 @@ import (
 // 6. スケジュールの更新が成功すること
 // 7. スケジュールの削除が成功すること
 
+// setupTestEnvironment はテスト実行前の環境設定を行う
+func setupTestEnvironment() {
+	// ローカルテスト実行時にFirestoreエミュレータを使用
+	if os.Getenv("FIRESTORE_EMULATOR_HOST") == "" {
+		os.Setenv("FIRESTORE_EMULATOR_HOST", "localhost:8081")
+	}
+}
+
 func TestScheduleRepository_Create(t *testing.T) {
+	// テスト環境でFirestoreエミュレータを使用
+	setupTestEnvironment()
+	
 	ctx := context.Background()
 	client, err := firestore.NewClient(ctx)
 	require.NoError(t, err)
@@ -48,6 +60,9 @@ func TestScheduleRepository_Create(t *testing.T) {
 }
 
 func TestScheduleRepository_GetByID(t *testing.T) {
+	// テスト環境でFirestoreエミュレータを使用
+	setupTestEnvironment()
+	
 	ctx := context.Background()
 	client, err := firestore.NewClient(ctx)
 	require.NoError(t, err)
@@ -81,6 +96,9 @@ func TestScheduleRepository_GetByID(t *testing.T) {
 }
 
 func TestScheduleRepository_GetByID_NotFound(t *testing.T) {
+	// テスト環境でFirestoreエミュレータを使用
+	setupTestEnvironment()
+	
 	ctx := context.Background()
 	client, err := firestore.NewClient(ctx)
 	require.NoError(t, err)


### PR DESCRIPTION
## 概要
Issue #23 で報告されたFirestoreエミュレータの権限エラーを修正しました。

## 問題
リポジトリレイヤーのテスト実行時に以下のエラーが発生していました：
```
rpc error: code = PermissionDenied desc = Permission denied on resource project kareru-local.
```

## 根本原因
テスト実行時に`FIRESTORE_EMULATOR_HOST`環境変数が適切に設定されておらず、Firestoreエミュレータへの接続に失敗していた。

## 修正内容

### 1. テスト環境の自動設定
- `setupTestEnvironment()`関数を追加
- テスト実行時に自動的に`FIRESTORE_EMULATOR_HOST=localhost:8081`を設定
- 全てのリポジトリテストで環境設定を適用

### 2. Makefileの改善
- `test-backend`ターゲットに環境変数設定を追加
- `test-backend-unit`: 単体テスト専用ターゲット
- `test-backend-integration`: 統合テスト専用ターゲット

### 修正ファイル
- `backend/internal/infrastructure/repository/schedule_test.go`
- `Makefile`

## テスト結果

### 修正前（エラー）
```bash
=== RUN   TestScheduleRepository_Create
--- FAIL: TestScheduleRepository_Create (0.58s)
```

### 修正後（成功）
```bash
=== RUN   TestScheduleRepository_Create
--- PASS: TestScheduleRepository_Create (0.06s)
=== RUN   TestScheduleRepository_GetByID
--- PASS: TestScheduleRepository_GetByID (0.04s)
=== RUN   TestScheduleRepository_GetByID_NotFound
--- PASS: TestScheduleRepository_GetByID_NotFound (0.03s)
```

## テスト手順

### 1. 環境の準備
```bash
# Firestoreエミュレータが起動していることを確認
docker-compose ps
```

### 2. 単体テストの実行
```bash
make test-backend-unit
```

### 3. 統合テストの実行
```bash
make test-backend-integration
```

### 4. 全体テストの実行
```bash
make test-backend
```

## Breaking Changes
なし

## 関連Issue
Closes #23

## レビューポイント
1. **環境設定**: setupTestEnvironment()関数の実装妥当性
2. **テスト安定性**: 環境変数設定の確実性
3. **メンテナンス性**: Makefileターゲットの使いやすさ

## 補足事項
- この修正により、ローカル開発環境でのテスト実行が安定します
- CI/CD環境でも同様の環境変数設定が必要になる場合があります
- Docker Compose環境では既存設定で正常動作します