### PR TITLE
[ISSUE] 公開ページ表示 (close #9)

### DIFF
--- a/frontend/src/app/schedule/[uuid]/layout.tsx
+++ b/frontend/src/app/schedule/[uuid]/layout.tsx
@@ -1,0 +1,15 @@
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'スケジュール表示 - Kareru',
+  description: 'スケジュールの詳細を確認できます',
+  robots: 'noindex, nofollow',
+}
+
+export default function ScheduleLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/frontend/src/app/schedule/[uuid]/page.test.tsx
+++ b/frontend/src/app/schedule/[uuid]/page.test.tsx
@@ -94,4 +94,17 @@ describe('SchedulePage', () => {
     
     expect(screen.queryByTestId('expired-label')).not.toBeInTheDocument()
   })
+
+  it('スケジュール未発見時にエラーメッセージを表示する', async () => {
+    mockGetSchedule.mockRejectedValue(new Error('Schedule not found'))
+    
+    const mockParams = { uuid: 'invalid-uuid' }
+    render(<SchedulePage params={mockParams} />)
+    
+    await waitFor(() => {
+      expect(screen.getByTestId('error-message')).toBeInTheDocument()
+    })
+    
+    expect(screen.getByText(/スケジュールが見つかりませんでした/)).toBeInTheDocument()
+  })
 })

--- a/frontend/src/app/schedule/[uuid]/page.test.tsx
+++ b/frontend/src/app/schedule/[uuid]/page.test.tsx
@@ -1,19 +1,46 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import SchedulePage from './page'
+import { getSchedule } from '../../../services/api'
 
-// API関数をモック
 jest.mock('../../../services/api', () => ({
   getSchedule: jest.fn(),
 }))
 
+const mockGetSchedule = getSchedule as jest.MockedFunction<typeof getSchedule>
+
 describe('SchedulePage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   it('UUID付きURLでページがレンダリングされる', async () => {
     const mockParams = { uuid: 'test-uuid-123' }
+    render(<SchedulePage params={mockParams} />)
+    expect(screen.getByTestId('schedule-page')).toBeInTheDocument()
+  })
+
+  it('スケジュールデータを取得して表示する', async () => {
+    const mockSchedule = {
+      id: 'test-uuid-123',
+      comment: 'テスト用スケジュール',
+      timeSlots: [{
+        startTime: new Date('2025-07-04T10:00:00Z'),
+        endTime: new Date('2025-07-04T11:00:00Z'),
+        available: true
+      }],
+      createdAt: new Date('2025-07-03T00:00:00Z'),
+      expiresAt: new Date('2025-07-10T00:00:00Z')
+    }
+
+    mockGetSchedule.mockResolvedValue(mockSchedule)
     
-    // ページコンポーネントをレンダリング
+    const mockParams = { uuid: 'test-uuid-123' }
     render(<SchedulePage params={mockParams} />)
     
-    // ページが表示されることを確認
-    expect(screen.getByTestId('schedule-page')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText('テスト用スケジュール')).toBeInTheDocument()
+    })
+    
+    expect(screen.getByTestId('time-slot-list')).toBeInTheDocument()
   })
 })

--- a/frontend/src/app/schedule/[uuid]/page.test.tsx
+++ b/frontend/src/app/schedule/[uuid]/page.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react'
+import SchedulePage from './page'
+
+// API関数をモック
+jest.mock('../../../services/api', () => ({
+  getSchedule: jest.fn(),
+}))
+
+describe('SchedulePage', () => {
+  it('UUID付きURLでページがレンダリングされる', async () => {
+    const mockParams = { uuid: 'test-uuid-123' }
+    
+    // ページコンポーネントをレンダリング
+    render(<SchedulePage params={mockParams} />)
+    
+    // ページが表示されることを確認
+    expect(screen.getByTestId('schedule-page')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/app/schedule/[uuid]/page.test.tsx
+++ b/frontend/src/app/schedule/[uuid]/page.test.tsx
@@ -43,4 +43,55 @@ describe('SchedulePage', () => {
     
     expect(screen.getByTestId('time-slot-list')).toBeInTheDocument()
   })
+
+  it('期限切れスケジュールに「期限切れ」ラベルを表示する', async () => {
+    const expiredSchedule = {
+      id: 'test-uuid-456',
+      comment: '期限切れスケジュール',
+      timeSlots: [{
+        startTime: new Date('2025-07-04T10:00:00Z'),
+        endTime: new Date('2025-07-04T11:00:00Z'),
+        available: true
+      }],
+      createdAt: new Date('2025-07-01T00:00:00Z'),
+      expiresAt: new Date('2025-07-02T00:00:00Z')
+    }
+
+    mockGetSchedule.mockResolvedValue(expiredSchedule)
+    
+    const mockParams = { uuid: 'test-uuid-456' }
+    render(<SchedulePage params={mockParams} />)
+    
+    await waitFor(() => {
+      expect(screen.getByText('期限切れスケジュール')).toBeInTheDocument()
+    })
+    
+    expect(screen.getByTestId('expired-label')).toBeInTheDocument()
+    expect(screen.getByText('期限切れ')).toBeInTheDocument()
+  })
+
+  it('正常なスケジュールには期限切れラベルを表示しない', async () => {
+    const validSchedule = {
+      id: 'test-uuid-789',
+      comment: '正常なスケジュール',
+      timeSlots: [{
+        startTime: new Date('2025-07-04T10:00:00Z'),
+        endTime: new Date('2025-07-04T11:00:00Z'),
+        available: true
+      }],
+      createdAt: new Date('2025-07-03T00:00:00Z'),
+      expiresAt: new Date('2025-07-10T00:00:00Z')
+    }
+
+    mockGetSchedule.mockResolvedValue(validSchedule)
+    
+    const mockParams = { uuid: 'test-uuid-789' }
+    render(<SchedulePage params={mockParams} />)
+    
+    await waitFor(() => {
+      expect(screen.getByText('正常なスケジュール')).toBeInTheDocument()
+    })
+    
+    expect(screen.queryByTestId('expired-label')).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/app/schedule/[uuid]/page.tsx
+++ b/frontend/src/app/schedule/[uuid]/page.tsx
@@ -12,25 +12,53 @@ interface Props {
 
 export default function SchedulePage({ params }: Props) {
   const [schedule, setSchedule] = useState<Schedule | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     const fetchSchedule = async () => {
       try {
+        setLoading(true)
         const data = await getSchedule(params.uuid)
         setSchedule(data)
+        setError(null)
       } catch (error) {
         console.error('Failed to fetch schedule:', error)
+        setError('スケジュールが見つかりませんでした')
+        setSchedule(null)
+      } finally {
+        setLoading(false)
       }
     }
 
     fetchSchedule()
   }, [params.uuid])
 
-  if (!schedule) {
+  if (loading) {
     return (
       <div data-testid="schedule-page">
         <h1>スケジュール表示</h1>
         <p>Loading...</p>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div data-testid="schedule-page">
+        <h1>スケジュール表示</h1>
+        <div data-testid="error-message" className="bg-red-100 text-red-600 px-4 py-2 rounded">
+          {error}
+        </div>
+      </div>
+    )
+  }
+
+  if (!schedule) {
+    return (
+      <div data-testid="schedule-page">
+        <h1>スケジュール表示</h1>
+        <p>スケジュールが見つかりません</p>
       </div>
     )
   }

--- a/frontend/src/app/schedule/[uuid]/page.tsx
+++ b/frontend/src/app/schedule/[uuid]/page.tsx
@@ -65,21 +65,68 @@ export default function SchedulePage({ params }: Props) {
 
   const isExpired = new Date(schedule.expiresAt) < new Date()
 
+  const formatDate = (date: Date) => {
+    return new Intl.DateTimeFormat('ja-JP', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    }).format(date)
+  }
+
+  const formatTime = (date: Date) => {
+    return new Intl.DateTimeFormat('ja-JP', {
+      hour: '2-digit',
+      minute: '2-digit'
+    }).format(date)
+  }
+
   return (
-    <div data-testid="schedule-page">
-      <h1>スケジュール表示</h1>
-      {isExpired && (
-        <div data-testid="expired-label" className="bg-red-100 text-red-600 px-2 py-1 rounded">
-          期限切れ
-        </div>
-      )}
-      <p>{schedule.comment}</p>
-      <div data-testid="time-slot-list">
-        {schedule.timeSlots.map((slot, index) => (
-          <div key={index}>
-            {new Date(slot.startTime).toLocaleTimeString()} - {new Date(slot.endTime).toLocaleTimeString()}
-          </div>
-        ))}
+    <div data-testid="schedule-page" className="min-h-screen bg-gray-50 py-8">
+      <div className="max-w-2xl mx-auto px-4">
+        <header className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900 mb-4">スケジュール表示</h1>
+          {isExpired && (
+            <div data-testid="expired-label" className="inline-block bg-red-100 text-red-700 px-3 py-1 rounded-full text-sm font-medium">
+              期限切れ
+            </div>
+          )}
+        </header>
+
+        <main className="bg-white rounded-lg shadow-sm border p-6">
+          <section className="mb-6">
+            <h2 className="text-lg font-semibold text-gray-800 mb-2">コメント</h2>
+            <p className="text-gray-600 leading-relaxed">{schedule.comment}</p>
+          </section>
+
+          <section className="mb-6">
+            <h2 className="text-lg font-semibold text-gray-800 mb-4">タイムスロット一覧</h2>
+            <div data-testid="time-slot-list" className="space-y-2">
+              {schedule.timeSlots.map((slot, index) => (
+                <div key={index} className="flex items-center p-3 bg-gray-50 rounded-lg">
+                  <div className="flex-1">
+                    <span className="text-gray-700 font-medium">
+                      {formatTime(new Date(slot.startTime))} - {formatTime(new Date(slot.endTime))}
+                    </span>
+                  </div>
+                  <div className={`px-2 py-1 rounded text-xs font-medium ${
+                    slot.available 
+                      ? 'bg-green-100 text-green-700' 
+                      : 'bg-gray-100 text-gray-600'
+                  }`}>
+                    {slot.available ? '利用可能' : '利用不可'}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <footer className="text-sm text-gray-500 space-y-1">
+            <p>作成日時: {formatDate(new Date(schedule.createdAt))}</p>
+            <p>有効期限: {formatDate(new Date(schedule.expiresAt))}</p>
+          </footer>
+        </main>
       </div>
     </div>
   )

--- a/frontend/src/app/schedule/[uuid]/page.tsx
+++ b/frontend/src/app/schedule/[uuid]/page.tsx
@@ -35,9 +35,16 @@ export default function SchedulePage({ params }: Props) {
     )
   }
 
+  const isExpired = new Date(schedule.expiresAt) < new Date()
+
   return (
     <div data-testid="schedule-page">
       <h1>スケジュール表示</h1>
+      {isExpired && (
+        <div data-testid="expired-label" className="bg-red-100 text-red-600 px-2 py-1 rounded">
+          期限切れ
+        </div>
+      )}
       <p>{schedule.comment}</p>
       <div data-testid="time-slot-list">
         {schedule.timeSlots.map((slot, index) => (

--- a/frontend/src/app/schedule/[uuid]/page.tsx
+++ b/frontend/src/app/schedule/[uuid]/page.tsx
@@ -1,3 +1,9 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { getSchedule } from '../../../services/api'
+import { Schedule } from '../../../types/schedule'
+
 interface Props {
   params: {
     uuid: string
@@ -5,10 +11,41 @@ interface Props {
 }
 
 export default function SchedulePage({ params }: Props) {
+  const [schedule, setSchedule] = useState<Schedule | null>(null)
+
+  useEffect(() => {
+    const fetchSchedule = async () => {
+      try {
+        const data = await getSchedule(params.uuid)
+        setSchedule(data)
+      } catch (error) {
+        console.error('Failed to fetch schedule:', error)
+      }
+    }
+
+    fetchSchedule()
+  }, [params.uuid])
+
+  if (!schedule) {
+    return (
+      <div data-testid="schedule-page">
+        <h1>スケジュール表示</h1>
+        <p>Loading...</p>
+      </div>
+    )
+  }
+
   return (
     <div data-testid="schedule-page">
       <h1>スケジュール表示</h1>
-      <p>UUID: {params.uuid}</p>
+      <p>{schedule.comment}</p>
+      <div data-testid="time-slot-list">
+        {schedule.timeSlots.map((slot, index) => (
+          <div key={index}>
+            {new Date(slot.startTime).toLocaleTimeString()} - {new Date(slot.endTime).toLocaleTimeString()}
+          </div>
+        ))}
+      </div>
     </div>
   )
 }

--- a/frontend/src/app/schedule/[uuid]/page.tsx
+++ b/frontend/src/app/schedule/[uuid]/page.tsx
@@ -1,0 +1,14 @@
+interface Props {
+  params: {
+    uuid: string
+  }
+}
+
+export default function SchedulePage({ params }: Props) {
+  return (
+    <div data-testid="schedule-page">
+      <h1>スケジュール表示</h1>
+      <p>UUID: {params.uuid}</p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- UUID付きURL（/schedule/[uuid]）でアクセス可能な公開ページを実装
- スケジュールスロット一覧の表示と期限切れラベルの表示機能を追加
- エラーハンドリングとレスポンシブ対応、SEO対応を含む

## 主な変更点
- `/schedule/[uuid]/page.tsx`: 公開ページコンポーネントを実装
- `/schedule/[uuid]/page.test.tsx`: 包括的なテストスイートを作成
- `/schedule/[uuid]/layout.tsx`: SEO対応のメタデータ設定を追加

## 実装した機能
- ✅ UUID付きURL（/schedule/:uuid）のルーティング
- ✅ スケジュールスロット一覧の表示
- ✅ 期限切れスケジュールの識別表示
- ✅ 期限切れラベルの表示
- ✅ スケジュール未発見時のエラー表示
- ✅ レスポンシブ対応
- ✅ SEO対応（meta tags等）

## Test plan
- [x] UUID付きURLでページアクセスが可能
- [x] スケジュールデータの取得・表示
- [x] 期限切れラベルの条件付き表示
- [x] エラーハンドリング（スケジュール未発見時）
- [x] レスポンシブデザインの確認
- [x] SEOメタデータの設定確認

## 技術詳細
- Next.js App Router使用
- TypeScript + React 18
- TailwindCSS でモダンなUIデザイン
- Jest + React Testing Library でテスト実装
- twada式TDD（LIST→RED→GREEN→REFACTOR）で開発

close #9