### PR TITLE
feat: 編集トークンベースAPIエンドポイントを実装

### DIFF
--- a/backend/internal/handlers/schedule.go
+++ b/backend/internal/handlers/schedule.go
@@ -12,6 +12,7 @@ import (
 type ScheduleRepository interface {
 	Create(schedule *model.Schedule) error
 	GetByID(id string) (*model.Schedule, error)
+	GetByEditToken(token string) (*model.Schedule, error)
 	Update(schedule *model.Schedule) error
 	Delete(id string) error
 }
@@ -342,4 +343,191 @@ func (h *ScheduleHandler) DeleteSchedule(c *gin.Context) {
 // DeleteScheduleRequest はスケジュール削除リクエスト
 type DeleteScheduleRequest struct {
 	EditToken string `json:"editToken"`
+}
+
+// GetScheduleByEditToken は編集トークンでスケジュール取得ハンドラー
+func (h *ScheduleHandler) GetScheduleByEditToken(c *gin.Context) {
+	token := c.Param("token")
+	if token == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "edit token is required",
+		})
+		return
+	}
+
+	// 編集トークンでスケジュールを取得
+	schedule, err := h.repo.GetByEditToken(token)
+	if err != nil {
+		c.JSON(http.StatusForbidden, gin.H{
+			"error": "編集権限がありません",
+		})
+		return
+	}
+
+	if schedule == nil {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": "schedule not found",
+		})
+		return
+	}
+
+	// 失効チェック
+	if schedule.IsExpired() {
+		c.JSON(http.StatusGone, gin.H{
+			"error": "schedule has expired",
+		})
+		return
+	}
+
+	// レスポンスを作成
+	response := GetScheduleResponse{
+		ID:        schedule.ID,
+		TimeSlots: schedule.TimeSlots,
+		Comment:   schedule.Comment,
+		CreatedAt: schedule.CreatedAt,
+		ExpiresAt: schedule.ExpiresAt,
+	}
+
+	c.JSON(http.StatusOK, response)
+}
+
+// UpdateScheduleByEditToken は編集トークンでスケジュール更新ハンドラー
+func (h *ScheduleHandler) UpdateScheduleByEditToken(c *gin.Context) {
+	token := c.Param("token")
+	if token == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "edit token is required",
+		})
+		return
+	}
+
+	var req UpdateScheduleByEditTokenRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "invalid request body",
+		})
+		return
+	}
+
+	// 編集トークンでスケジュールを取得
+	schedule, err := h.repo.GetByEditToken(token)
+	if err != nil {
+		c.JSON(http.StatusForbidden, gin.H{
+			"error": "編集権限がありません",
+		})
+		return
+	}
+
+	if schedule == nil {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": "schedule not found",
+		})
+		return
+	}
+
+	// 失効チェック
+	if schedule.IsExpired() {
+		c.JSON(http.StatusGone, gin.H{
+			"error": "schedule has expired",
+		})
+		return
+	}
+
+	// リクエストからタイムスロットを変換
+	timeSlots := make([]model.TimeSlot, len(req.TimeSlots))
+	for i, ts := range req.TimeSlots {
+		timeSlots[i] = model.TimeSlot{
+			StartTime: ts.StartTime,
+			EndTime:   ts.EndTime,
+			Available: ts.Available,
+		}
+	}
+
+	// スケジュールを更新
+	schedule.TimeSlots = timeSlots
+	schedule.Comment = req.Comment
+
+	// バリデーション
+	if err := schedule.ValidateTimeSlots(); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": err.Error(),
+		})
+		return
+	}
+
+	// リポジトリで更新
+	if err := h.repo.Update(schedule); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "failed to update schedule",
+		})
+		return
+	}
+
+	// レスポンスを作成
+	response := GetScheduleResponse{
+		ID:        schedule.ID,
+		TimeSlots: schedule.TimeSlots,
+		Comment:   schedule.Comment,
+		CreatedAt: schedule.CreatedAt,
+		ExpiresAt: schedule.ExpiresAt,
+	}
+
+	c.JSON(http.StatusOK, response)
+}
+
+// DeleteScheduleByEditToken は編集トークンでスケジュール削除ハンドラー
+func (h *ScheduleHandler) DeleteScheduleByEditToken(c *gin.Context) {
+	token := c.Param("token")
+	if token == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "edit token is required",
+		})
+		return
+	}
+
+	// 編集トークンでスケジュールを取得
+	schedule, err := h.repo.GetByEditToken(token)
+	if err != nil {
+		c.JSON(http.StatusForbidden, gin.H{
+			"error": "編集権限がありません",
+		})
+		return
+	}
+
+	if schedule == nil {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": "schedule not found",
+		})
+		return
+	}
+
+	// 失効チェック
+	if schedule.IsExpired() {
+		c.JSON(http.StatusGone, gin.H{
+			"error": "schedule has expired",
+		})
+		return
+	}
+
+	// スケジュールを削除
+	if err := h.repo.Delete(schedule.ID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "failed to delete schedule",
+		})
+		return
+	}
+
+	c.JSON(http.StatusNoContent, nil)
+}
+
+// UpdateScheduleByEditTokenRequest は編集トークンでスケジュール更新リクエスト
+type UpdateScheduleByEditTokenRequest struct {
+	TimeSlots []EditTimeSlotRequest `json:"timeSlots"`
+	Comment   string                `json:"comment"`
+}
+
+type EditTimeSlotRequest struct {
+	StartTime time.Time `json:"startTime"`
+	EndTime   time.Time `json:"endTime"`
+	Available bool      `json:"available"`
 }

--- a/backend/internal/infrastructure/repository/memory_schedule.go
+++ b/backend/internal/infrastructure/repository/memory_schedule.go
@@ -60,3 +60,15 @@ func (r *MemoryScheduleRepository) Delete(id string) error {
 	delete(r.schedules, id)
 	return nil
 }
+
+func (r *MemoryScheduleRepository) GetByEditToken(token string) (*model.Schedule, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	
+	for _, schedule := range r.schedules {
+		if schedule.EditToken == token {
+			return schedule, nil
+		}
+	}
+	return nil, fmt.Errorf("schedule not found")
+}

--- a/backend/internal/routes/routes.go
+++ b/backend/internal/routes/routes.go
@@ -17,6 +17,14 @@ func SetupRoutes(router *gin.Engine, scheduleHandler *handlers.ScheduleHandler) 
 			schedules.GET("/:uuid", scheduleHandler.GetSchedule)
 			schedules.PUT("/:uuid", scheduleHandler.UpdateSchedule)
 			schedules.DELETE("/:uuid", scheduleHandler.DeleteSchedule)
+			
+			// 編集トークンベースのエンドポイント
+			edit := schedules.Group("/edit")
+			{
+				edit.GET("/:token", scheduleHandler.GetScheduleByEditToken)
+				edit.PUT("/:token", scheduleHandler.UpdateScheduleByEditToken)
+				edit.DELETE("/:token", scheduleHandler.DeleteScheduleByEditToken)
+			}
 		}
 	}
 

--- a/frontend/src/app/edit/[token]/page.tsx
+++ b/frontend/src/app/edit/[token]/page.tsx
@@ -17,6 +17,7 @@ export default function EditPage({ params }: Props) {
   const [comment, setComment] = useState('')
   const [timeSlots, setTimeSlots] = useState<Schedule['timeSlots']>([])
   const [saving, setSaving] = useState(false)
+  const [success, setSuccess] = useState(false)
 
   useEffect(() => {
     const fetchSchedule = async () => {
@@ -44,11 +45,14 @@ export default function EditPage({ params }: Props) {
 
     try {
       setSaving(true)
+      setError(null)
+      setSuccess(false)
       await updateSchedule(params.token, {
         comment,
         timeSlots
       })
-      // 成功通知などは後で実装
+      setSuccess(true)
+      setTimeout(() => setSuccess(false), 3000)
     } catch (error) {
       console.error('Failed to update schedule:', error)
       setError('更新に失敗しました')
@@ -93,36 +97,75 @@ export default function EditPage({ params }: Props) {
   }
 
   return (
-    <div data-testid="edit-page">
-      <h1>スケジュール編集</h1>
-      <form data-testid="edit-form" onSubmit={(e) => { e.preventDefault(); handleSave(); }}>
+    <div data-testid="edit-page" className="max-w-2xl mx-auto p-6 bg-white rounded-lg shadow-lg">
+      <h1 className="text-2xl font-bold text-gray-900 mb-6">スケジュール編集</h1>
+      <form data-testid="edit-form" onSubmit={(e) => { e.preventDefault(); handleSave(); }} className="space-y-6">
         <div>
-          <label htmlFor="comment">コメント:</label>
-          <input
+          <label htmlFor="comment" className="block text-sm font-medium text-gray-700 mb-2">
+            コメント:
+          </label>
+          <textarea
             id="comment"
-            type="text"
             value={comment}
             onChange={(e) => setComment(e.target.value)}
+            className="w-full p-3 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            rows={3}
+            placeholder="スケジュールについてのコメントを入力してください"
           />
         </div>
         
         <div data-testid="timeslot-list">
-          <h3>タイムスロット:</h3>
-          {timeSlots.map((slot, index) => (
-            <div key={index}>
-              <label>
+          <h3 className="text-lg font-medium text-gray-900 mb-4">タイムスロット:</h3>
+          <div className="space-y-3">
+            {timeSlots.map((slot, index) => (
+              <div key={index} className="flex items-center p-4 border border-gray-200 rounded-md bg-gray-50">
                 <input
                   type="checkbox"
                   checked={slot.Available}
                   onChange={() => toggleTimeSlot(index)}
+                  className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
                 />
-                {new Date(slot.StartTime).toLocaleTimeString()} - {new Date(slot.EndTime).toLocaleTimeString()}
-              </label>
-            </div>
-          ))}
+                <label className="ml-3 flex-1">
+                  <span className="text-sm font-medium text-gray-900">
+                    {new Date(slot.StartTime).toLocaleString('ja-JP', {
+                      year: 'numeric',
+                      month: 'short',
+                      day: 'numeric',
+                      hour: '2-digit',
+                      minute: '2-digit'
+                    })} 
+                    ～ 
+                    {new Date(slot.EndTime).toLocaleString('ja-JP', {
+                      hour: '2-digit',
+                      minute: '2-digit'
+                    })}
+                  </span>
+                  <div className="text-xs text-gray-500 mt-1">
+                    {slot.Available ? '✅ 利用可能' : '❌ 利用不可'}
+                  </div>
+                </label>
+              </div>
+            ))}
+          </div>
         </div>
 
-        <button type="submit" disabled={saving}>
+        {error && (
+          <div className="text-red-600 text-sm bg-red-50 p-3 rounded-md">
+            {error}
+          </div>
+        )}
+
+        {success && (
+          <div className="text-green-600 text-sm bg-green-50 p-3 rounded-md">
+            ✅ スケジュールが正常に更新されました
+          </div>
+        )}
+
+        <button 
+          type="submit" 
+          disabled={saving}
+          className="w-full bg-blue-600 text-white py-3 px-4 rounded-md hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+        >
           {saving ? '保存中...' : '保存'}
         </button>
       </form>

--- a/frontend/src/hooks/useScheduleForm.ts
+++ b/frontend/src/hooks/useScheduleForm.ts
@@ -1,16 +1,16 @@
 import { useState } from 'react'
-import { TimeSlot, Schedule, CreateScheduleResponse } from '../types/schedule'
+import { FormTimeSlot, FormSchedule, CreateScheduleResponse } from '../types/schedule'
 import { createSchedule } from '../services/api'
 
 export function useScheduleForm() {
   const [comment, setComment] = useState('')
-  const [timeSlots, setTimeSlots] = useState<TimeSlot[]>([])
+  const [timeSlots, setTimeSlots] = useState<FormTimeSlot[]>([])
   const [error, setError] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [successData, setSuccessData] = useState<CreateScheduleResponse | null>(null)
 
   const addTimeSlot = () => {
-    const newSlot: TimeSlot = {
+    const newSlot: FormTimeSlot = {
       id: Date.now().toString(),
       startTime: '',
       endTime: ''

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,8 +1,8 @@
-import { CreateScheduleResponse, Schedule } from '../types/schedule'
+import { CreateScheduleResponse, Schedule, FormSchedule } from '../types/schedule'
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080'
 
-export async function createSchedule(schedule: Omit<Schedule, 'id' | 'editToken' | 'createdAt' | 'expiresAt'>): Promise<CreateScheduleResponse> {
+export async function createSchedule(schedule: Omit<FormSchedule, 'id' | 'editToken' | 'createdAt' | 'expiresAt'>): Promise<CreateScheduleResponse> {
   const response = await fetch(`${API_BASE_URL}/api/v1/schedules`, {
     method: 'POST',
     headers: {
@@ -53,8 +53,8 @@ export async function updateSchedule(token: string, schedule: Omit<Schedule, 'id
     body: JSON.stringify({
       comment: schedule.comment,
       timeSlots: schedule.timeSlots.map(slot => ({
-        startTime: slot.StartTime,
-        endTime: slot.EndTime,
+        startTime: new Date(slot.StartTime).toISOString(),
+        endTime: new Date(slot.EndTime).toISOString(),
         available: slot.Available,
       })),
     }),

--- a/frontend/src/types/schedule.ts
+++ b/frontend/src/types/schedule.ts
@@ -5,10 +5,25 @@ export interface TimeSlot {
   Available: boolean
 }
 
+export interface FormTimeSlot {
+  id?: string
+  startTime: string
+  endTime: string
+}
+
 export interface Schedule {
   id?: string
   comment: string
   timeSlots: TimeSlot[]
+  editToken?: string
+  createdAt?: string
+  expiresAt?: string
+}
+
+export interface FormSchedule {
+  id?: string
+  comment: string
+  timeSlots: FormTimeSlot[]
   editToken?: string
   createdAt?: string
   expiresAt?: string


### PR DESCRIPTION
## 概要
編集ページでの「編集権限がありません」エラーを解決するため、編集トークンベースのAPIエンドポイントを実装しました。これにより編集URLからスケジュールの編集・削除が正常に動作するようになります。

## 関連Issue
Closes #32

## 変更種別
- [x] ✨ 新機能
- [x] 🐛 バグ修正

## 変更内容
### 何を変更したか
- GET /api/v1/schedules/edit/{token}: 編集トークンでスケジュール取得APIを追加
- PUT /api/v1/schedules/edit/{token}: 編集トークンでスケジュール更新APIを追加
- DELETE /api/v1/schedules/edit/{token}: 編集トークンでスケジュール削除APIを追加
- メモリリポジトリにGetByEditTokenメソッドを実装
- フロントエンド型定義を整理（FormTimeSlot/FormSchedule追加）

### なぜ変更したか
- 編集ページアクセス時に404エラーが発生していた
- バックエンドに編集トークンベースのAPIエンドポイントが存在しなかった
- フロントエンドとバックエンドの型定義に不整合があった

---

## 🤖 Claude 自動確認項目
- [x] `npm run build` が成功
- [x] 型エラーの解消
- [x] 不要なconsole.log/print文の削除

---

## 動作確認手順
1. スケジュール作成フォームでスケジュールを作成
2. 成功画面に表示される編集URLをコピー
3. 編集URLにアクセスして編集ページが正常に表示されることを確認
4. スケジュールのコメントやタイムスロットを変更して保存
5. 変更が正常に反映されることを確認

## スクリーンショット
編集ページが正常に表示され、「編集権限がありません」エラーが解消される。

## 特に見てほしい箇所
- handlers/schedule.goの新しいエンドポイント実装
- 編集トークンによるセキュリティ検証ロジック
- フロントエンド型定義の整理と整合性