### PR TITLE
URLルーティング設計 (close #11)

### DIFF
--- a/frontend/src/app/edit/[token]/page.tsx
+++ b/frontend/src/app/edit/[token]/page.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState } from 'react'
 import { getScheduleByToken, updateSchedule } from '../../../services/api'
 import { Schedule } from '../../../types/schedule'
+import { validateEditURL } from '../../../utils/url-validation'
+import { notFound } from 'next/navigation'
 
 interface Props {
   params: {
@@ -20,6 +22,13 @@ export default function EditPage({ params }: Props) {
   const [success, setSuccess] = useState(false)
 
   useEffect(() => {
+    // URLバリデーションをチェック
+    const validation = validateEditURL(params.token)
+    if (!validation.isValid) {
+      notFound()
+      return
+    }
+
     const fetchSchedule = async () => {
       try {
         setLoading(true)

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,10 +1,8 @@
 import type { Metadata } from 'next'
 import './globals.css'
+import { generateMetadata } from '../utils/seo-metadata'
 
-export const metadata: Metadata = {
-  title: 'Kareru - 手軽な日程共有',
-  description: 'ログイン不要で空き日程をすぐ公開・共有',
-}
+export const metadata: Metadata = generateMetadata()
 
 export default function RootLayout({
   children,

--- a/frontend/src/app/not-found.test.tsx
+++ b/frontend/src/app/not-found.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react'
+import NotFound from './not-found'
+
+describe('NotFound Page', () => {
+  it('should render 404 error message', () => {
+    render(<NotFound />)
+    expect(screen.getByText('404')).toBeInTheDocument()
+    expect(screen.getByText('ページが見つかりません')).toBeInTheDocument()
+  })
+
+  it('should render home link', () => {
+    render(<NotFound />)
+    const homeLink = screen.getByRole('link', { name: /ホームに戻る/i })
+    expect(homeLink).toBeInTheDocument()
+    expect(homeLink).toHaveAttribute('href', '/')
+  })
+
+  it('should render create schedule link', () => {
+    render(<NotFound />)
+    const createLink = screen.getByRole('link', { name: /新しいスケジュールを作成/i })
+    expect(createLink).toBeInTheDocument()
+    expect(createLink).toHaveAttribute('href', '/create')
+  })
+
+  it('should have proper styling', () => {
+    render(<NotFound />)
+    const container = screen.getByTestId('not-found-page')
+    expect(container).toBeInTheDocument()
+  })
+})

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,39 @@
+import Link from 'next/link'
+
+export default function NotFound() {
+  return (
+    <div data-testid="not-found-page" className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="max-w-md mx-auto text-center">
+        <div className="mb-8">
+          <h1 className="text-9xl font-bold text-gray-300">404</h1>
+          <h2 className="text-2xl font-semibold text-gray-900 mt-4">
+            ページが見つかりません
+          </h2>
+          <p className="text-gray-600 mt-2">
+            お探しのページは存在しないか、移動された可能性があります。
+          </p>
+        </div>
+        
+        <div className="space-y-4">
+          <Link
+            href="/"
+            className="inline-block w-full bg-blue-600 text-white py-3 px-6 rounded-md hover:bg-blue-700 transition-colors font-medium"
+          >
+            ホームに戻る
+          </Link>
+          
+          <Link
+            href="/create"
+            className="inline-block w-full bg-gray-600 text-white py-3 px-6 rounded-md hover:bg-gray-700 transition-colors font-medium"
+          >
+            新しいスケジュールを作成
+          </Link>
+        </div>
+        
+        <div className="mt-8 text-sm text-gray-500">
+          <p>問題が続く場合は、URLが正しいか確認してください。</p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,4 +1,9 @@
 import Link from 'next/link'
+import { generateNotFoundMetadata } from '../utils/seo-metadata'
+
+export async function generateMetadata() {
+  return generateNotFoundMetadata()
+}
 
 export default function NotFound() {
   return (

--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react'
+import { useRouter } from 'next/navigation'
+import Home from './page'
+
+// Next.js routerをモック
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}))
+
+describe('Home Page', () => {
+  const mockPush = jest.fn()
+  
+  beforeEach(() => {
+    (useRouter as jest.Mock).mockReturnValue({
+      push: mockPush,
+    })
+    jest.clearAllMocks()
+  })
+
+  it('should redirect to create page after 2 seconds', async () => {
+    jest.useFakeTimers()
+    render(<Home />)
+    
+    expect(screen.getByText('リダイレクト中...')).toBeInTheDocument()
+    
+    jest.advanceTimersByTime(2000)
+    
+    expect(mockPush).toHaveBeenCalledWith('/create')
+    jest.useRealTimers()
+  })
+
+  it('should show redirect message', () => {
+    render(<Home />)
+    expect(screen.getByText('スケジュール作成ページに移動します')).toBeInTheDocument()
+  })
+
+  it('should have manual link to create page', () => {
+    render(<Home />)
+    const createLink = screen.getByRole('link', { name: /今すぐ作成/i })
+    expect(createLink).toBeInTheDocument()
+    expect(createLink).toHaveAttribute('href', '/create')
+  })
+
+  it('should display loading spinner', () => {
+    render(<Home />)
+    const spinner = screen.getByTestId('loading-spinner')
+    expect(spinner).toBeInTheDocument()
+  })
+})

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,20 +1,45 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+
 export default function Home() {
+  const router = useRouter()
+
+  useEffect(() => {
+    const redirectTimer = setTimeout(() => {
+      router.push('/create')
+    }, 2000)
+
+    return () => clearTimeout(redirectTimer)
+  }, [router])
+
   return (
     <main className="min-h-screen bg-gray-50 flex items-center justify-center">
       <div className="text-center">
         <h1 className="text-4xl font-bold text-gray-900 mb-4">
           Kareru
         </h1>
-        <p className="text-gray-600 mb-8">
+        <p className="text-gray-600 mb-4">
           手軽な日程共有サービス
         </p>
+        
+        <div className="mb-8">
+          <div data-testid="loading-spinner" className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mb-4"></div>
+          <p className="text-blue-600 font-medium">リダイレクト中...</p>
+          <p className="text-gray-500 text-sm mt-2">
+            スケジュール作成ページに移動します
+          </p>
+        </div>
+        
         <div className="space-y-4">
-          <a 
+          <Link 
             href="/create" 
             className="inline-block bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700 transition-colors"
           >
-            スケジュールを作成
-          </a>
+            今すぐ作成
+          </Link>
         </div>
       </div>
     </main>

--- a/frontend/src/app/schedule/[uuid]/page.tsx
+++ b/frontend/src/app/schedule/[uuid]/page.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState } from 'react'
 import { getSchedule } from '../../../services/api'
 import { Schedule } from '../../../types/schedule'
+import { validateScheduleURL } from '../../../utils/url-validation'
+import { notFound } from 'next/navigation'
 
 interface Props {
   params: {
@@ -16,6 +18,13 @@ export default function SchedulePage({ params }: Props) {
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
+    // URLバリデーションをチェック
+    const validation = validateScheduleURL(params.uuid)
+    if (!validation.isValid) {
+      notFound()
+      return
+    }
+
     const fetchSchedule = async () => {
       try {
         setLoading(true)

--- a/frontend/src/utils/seo-metadata.test.ts
+++ b/frontend/src/utils/seo-metadata.test.ts
@@ -1,0 +1,70 @@
+import { generateMetadata, generateScheduleMetadata, generateEditMetadata, generateNotFoundMetadata } from './seo-metadata'
+
+describe('SEO Metadata Utils', () => {
+  describe('generateMetadata', () => {
+    it('should generate default metadata', () => {
+      const metadata = generateMetadata()
+      
+      expect(metadata.title).toBe('Kareru - 手軽な日程共有サービス')
+      expect(metadata.description).toBe('手軽にスケジュールを作成・共有できるサービスです。UUID付きURLで安全にスケジュールを共有し、編集権限も管理できます。')
+      expect(metadata.keywords).toContain('スケジュール')
+      expect(metadata.openGraph.title).toBe('Kareru - 手軽な日程共有サービス')
+      expect(metadata.twitter.card).toBe('summary')
+    })
+
+    it('should generate custom metadata', () => {
+      const customTitle = 'カスタムタイトル'
+      const customDescription = 'カスタム説明'
+      
+      const metadata = generateMetadata(customTitle, customDescription)
+      
+      expect(metadata.title).toBe(customTitle)
+      expect(metadata.description).toBe(customDescription)
+      expect(metadata.openGraph.title).toBe(customTitle)
+      expect(metadata.openGraph.description).toBe(customDescription)
+    })
+  })
+
+  describe('generateScheduleMetadata', () => {
+    it('should generate schedule-specific metadata', () => {
+      const scheduleId = 'ee284ba1-ecbe-4997-ae7e-3877b2cd7db7'
+      const comment = 'チームミーティング'
+      
+      const metadata = generateScheduleMetadata(scheduleId, comment)
+      
+      expect(metadata.title).toContain('チームミーティング')
+      expect(metadata.description).toContain('チームミーティング')
+      expect(metadata.openGraph.url).toContain(scheduleId)
+      expect(metadata.robots).toBe('noindex, nofollow')
+    })
+
+    it('should handle empty comment', () => {
+      const scheduleId = 'ee284ba1-ecbe-4997-ae7e-3877b2cd7db7'
+      
+      const metadata = generateScheduleMetadata(scheduleId)
+      
+      expect(metadata.title).toBe('スケジュール表示 - Kareru')
+      expect(metadata.description).toContain('スケジュール情報')
+    })
+  })
+
+  describe('generateEditMetadata', () => {
+    it('should generate edit page metadata', () => {
+      const metadata = generateEditMetadata()
+      
+      expect(metadata.title).toBe('スケジュール編集 - Kareru')
+      expect(metadata.description).toContain('編集画面')
+      expect(metadata.robots).toBe('noindex, nofollow')
+    })
+  })
+
+  describe('generateNotFoundMetadata', () => {
+    it('should generate 404 page metadata', () => {
+      const metadata = generateNotFoundMetadata()
+      
+      expect(metadata.title).toBe('ページが見つかりません - Kareru')
+      expect(metadata.description).toContain('404')
+      expect(metadata.robots).toBe('noindex, nofollow')
+    })
+  })
+})

--- a/frontend/src/utils/seo-metadata.ts
+++ b/frontend/src/utils/seo-metadata.ts
@@ -1,0 +1,82 @@
+import { Metadata } from 'next'
+
+/**
+ * 基本のSEOメタデータを生成する
+ */
+export function generateMetadata(
+  title: string = 'Kareru - 手軽な日程共有サービス',
+  description: string = '手軽にスケジュールを作成・共有できるサービスです。UUID付きURLで安全にスケジュールを共有し、編集権限も管理できます。'
+): Metadata {
+  return {
+    title,
+    description,
+    keywords: ['スケジュール', '日程調整', '共有', 'UUID', '編集', 'Kareru'],
+    authors: [{ name: 'Kareru Team' }],
+    creator: 'Kareru',
+    publisher: 'Kareru',
+    robots: 'index, follow',
+    openGraph: {
+      title,
+      description,
+      type: 'website',
+      locale: 'ja_JP',
+      siteName: 'Kareru',
+    },
+    twitter: {
+      card: 'summary',
+      title,
+      description,
+      creator: '@kareru',
+    },
+    viewport: 'width=device-width, initial-scale=1',
+    themeColor: '#2563eb', // blue-600
+  }
+}
+
+/**
+ * スケジュール表示ページ用のメタデータを生成する
+ */
+export function generateScheduleMetadata(
+  scheduleId: string,
+  comment?: string
+): Metadata {
+  const title = comment ? `${comment} - スケジュール表示 - Kareru` : 'スケジュール表示 - Kareru'
+  const description = comment 
+    ? `「${comment}」のスケジュール情報をご確認いただけます。利用可能な時間帯をご確認ください。`
+    : 'スケジュール情報をご確認いただけます。利用可能な時間帯をご確認ください。'
+
+  return {
+    ...generateMetadata(title, description),
+    robots: 'noindex, nofollow', // プライベートコンテンツなので検索エンジンからは除外
+    openGraph: {
+      ...generateMetadata(title, description).openGraph,
+      url: `/schedule/${scheduleId}`,
+    },
+  }
+}
+
+/**
+ * 編集ページ用のメタデータを生成する
+ */
+export function generateEditMetadata(): Metadata {
+  const title = 'スケジュール編集 - Kareru'
+  const description = 'スケジュールの編集画面です。タイムスロットの利用可能状況を変更できます。'
+
+  return {
+    ...generateMetadata(title, description),
+    robots: 'noindex, nofollow', // プライベートページなので検索エンジンからは除外
+  }
+}
+
+/**
+ * 404ページ用のメタデータを生成する
+ */
+export function generateNotFoundMetadata(): Metadata {
+  const title = 'ページが見つかりません - Kareru'
+  const description = '404エラー: お探しのページは存在しないか、移動された可能性があります。'
+
+  return {
+    ...generateMetadata(title, description),
+    robots: 'noindex, nofollow', // エラーページなので検索エンジンからは除外
+  }
+}

--- a/frontend/src/utils/url-validation.test.ts
+++ b/frontend/src/utils/url-validation.test.ts
@@ -1,0 +1,73 @@
+import { isValidUUID, isValidEditToken, validateScheduleURL, validateEditURL } from './url-validation'
+
+describe('URL Validation Utils', () => {
+  describe('isValidUUID', () => {
+    it('should return true for valid UUID v4', () => {
+      const validUUID = 'ee284ba1-ecbe-4997-ae7e-3877b2cd7db7'
+      expect(isValidUUID(validUUID)).toBe(true)
+    })
+
+    it('should return false for invalid UUID format', () => {
+      expect(isValidUUID('invalid-uuid')).toBe(false)
+      expect(isValidUUID('123-456-789')).toBe(false)
+      expect(isValidUUID('')).toBe(false)
+      expect(isValidUUID('ee284ba1-ecbe-4997-ae7e')).toBe(false)
+    })
+
+    it('should return false for non-string input', () => {
+      expect(isValidUUID(null as any)).toBe(false)
+      expect(isValidUUID(undefined as any)).toBe(false)
+      expect(isValidUUID(123 as any)).toBe(false)
+    })
+  })
+
+  describe('isValidEditToken', () => {
+    it('should return true for valid edit token (64 hex characters)', () => {
+      const validToken = '5b521bc840d1b9d806dc97cb8efb5d6a41d0e737379fcd591f485e27b54f48fa'
+      expect(isValidEditToken(validToken)).toBe(true)
+    })
+
+    it('should return false for invalid edit token', () => {
+      expect(isValidEditToken('short-token')).toBe(false)
+      expect(isValidEditToken('')).toBe(false)
+      expect(isValidEditToken('invalid-characters-!@#$')).toBe(false)
+    })
+
+    it('should return false for wrong length', () => {
+      const shortToken = '5b521bc840d1b9d806dc97cb8efb5d6a41d0e737379fcd591f485e27b54f48f'
+      const longToken = '5b521bc840d1b9d806dc97cb8efb5d6a41d0e737379fcd591f485e27b54f48faa'
+      expect(isValidEditToken(shortToken)).toBe(false)
+      expect(isValidEditToken(longToken)).toBe(false)
+    })
+  })
+
+  describe('validateScheduleURL', () => {
+    it('should return valid for correct schedule URL', () => {
+      const uuid = 'ee284ba1-ecbe-4997-ae7e-3877b2cd7db7'
+      const result = validateScheduleURL(uuid)
+      expect(result.isValid).toBe(true)
+      expect(result.error).toBeNull()
+    })
+
+    it('should return invalid for malformed UUID', () => {
+      const result = validateScheduleURL('invalid-uuid')
+      expect(result.isValid).toBe(false)
+      expect(result.error).toBe('無効なスケジュールIDです')
+    })
+  })
+
+  describe('validateEditURL', () => {
+    it('should return valid for correct edit token', () => {
+      const token = '5b521bc840d1b9d806dc97cb8efb5d6a41d0e737379fcd591f485e27b54f48fa'
+      const result = validateEditURL(token)
+      expect(result.isValid).toBe(true)
+      expect(result.error).toBeNull()
+    })
+
+    it('should return invalid for malformed edit token', () => {
+      const result = validateEditURL('invalid-token')
+      expect(result.isValid).toBe(false)
+      expect(result.error).toBe('無効な編集トークンです')
+    })
+  })
+})

--- a/frontend/src/utils/url-validation.ts
+++ b/frontend/src/utils/url-validation.ts
@@ -1,0 +1,65 @@
+/**
+ * UUID v4の形式を検証する
+ */
+export function isValidUUID(uuid: any): boolean {
+  if (typeof uuid !== 'string') {
+    return false
+  }
+  
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+  return uuidRegex.test(uuid)
+}
+
+/**
+ * 編集トークンの形式を検証する（64文字の16進数）
+ */
+export function isValidEditToken(token: any): boolean {
+  if (typeof token !== 'string') {
+    return false
+  }
+  
+  const tokenRegex = /^[0-9a-f]{64}$/i
+  return tokenRegex.test(token)
+}
+
+/**
+ * バリデーション結果の型定義
+ */
+export interface ValidationResult {
+  isValid: boolean
+  error: string | null
+}
+
+/**
+ * スケジュールURLのバリデーション
+ */
+export function validateScheduleURL(uuid: string): ValidationResult {
+  if (!isValidUUID(uuid)) {
+    return {
+      isValid: false,
+      error: '無効なスケジュールIDです'
+    }
+  }
+  
+  return {
+    isValid: true,
+    error: null
+  }
+}
+
+/**
+ * 編集URLのバリデーション
+ */
+export function validateEditURL(token: string): ValidationResult {
+  if (!isValidEditToken(token)) {
+    return {
+      isValid: false,
+      error: '無効な編集トークンです'
+    }
+  }
+  
+  return {
+    isValid: true,
+    error: null
+  }
+}


### PR DESCRIPTION
- **feat: スケジュールデータモデルを実装**
- **fix: backendディレクトリの入れ子構造を修正**
- **trigger: GitHubのマージ状態を更新**
- **fix: コードフォーマットを統一してgo fmtに準拠**
- **feat: スケジュールCRUD API実装**
- **fix: Firestoreエミュレータ権限エラーを解決**
- **feat: 基本的な時間スロット生成機能を実装**
- **refactor: TimeSlotManagerに営業時間管理機能を追加**
- **test: 3時間/6時間刻みの時間スロット生成テストを追加**
- **feat: スロット重複チェック機能を実装**
- **feat: 営業時間外スロット除外機能を実装**
- **feat: スケジュール自動失効機能を強化**
- **refactor: 日数計算ロジックを改善**
- **feat: ハンドラー層の失効制御機能を完成**
- **feat: 基本的なスケジュール登録フォームコンポーネントを実装**
- **refactor: フォームロジックをカスタムフックに分離**
- **feat: バックエンドAPI連携とURL表示機能を実装**
- **fix: スケジュール登録APIの統合とDocker環境対応を実装**
- **test(red): UUID付きページのルーティングテストを追加**
- **feat: スケジュール取得・表示機能を実装**
- **feat: 期限切れラベル表示機能を実装**
- **feat: エラーハンドリング機能を実装**
- **refactor: UIデザインとSEO対応を改善**
- **fix: Invalid time valueエラーを修正**
- **fix: バックエンドAPIデータ形式に対応**
- **fix: タイムスロット表示を「参加可能/参加不可」に変更**
- **test(red): 編集トークン認証テストを追加**
- **feat: スケジュール編集フォーム機能を実装**
- **fix: スケジュール公開URLのパスを修正**
- **feat: スケジュール作成成功画面に編集URLを追加**
- **docs: CLAUDE.mdファイルを追加**
- **feat: 編集トークンベースAPIエンドポイントを実装**
- **feat: 編集ページのUI/UXを改善**
- **test(red): 404エラーページのテストを追加**
- **feat: カスタム404ページを実装**
- **test(red): URLパターンバリデーションテストを追加**
- **feat: URLバリデーション機能を実装**
- **test(red): リダイレクト処理のテストを追加**
- **feat: ホームページにリダイレクト処理を実装**
- **test(red): SEOメタデータ生成テストを追加**
- **feat: SEOメタデータ生成機能を実装**
- **refactor: ルーティング構造とSEO最適化を完了**
