### PR TITLE
fix: APIレスポンスの型チェックエラーを修正 (#50)

### DIFF
--- a/frontend/src/types/schedule.ts
+++ b/frontend/src/types/schedule.ts
@@ -2,6 +2,7 @@ export interface TimeSlot {
   id?: string
   StartTime: string
   EndTime: string
+  Available?: boolean
 }
 
 export interface FormTimeSlot {

--- a/frontend/src/utils/runtime-type-check.ts
+++ b/frontend/src/utils/runtime-type-check.ts
@@ -54,10 +54,9 @@ export function isCreateScheduleResponse(data: unknown): data is CreateScheduleR
     isArray(data.timeSlots) &&
     data.timeSlots.every(slot => 
       isObject(slot) &&
-      isString(slot.id) &&
       isString(slot.StartTime) &&
       isString(slot.EndTime) &&
-      isBoolean(slot.Available)
+      (slot.Available === undefined || isBoolean(slot.Available))
     ) &&
     isString(data.createdAt) &&
     isString(data.expiresAt)
@@ -78,10 +77,9 @@ export function isSchedule(data: unknown): data is Schedule {
     isArray(data.timeSlots) &&
     data.timeSlots.every(slot => 
       isObject(slot) &&
-      isString(slot.id) &&
       isString(slot.StartTime) &&
       isString(slot.EndTime) &&
-      isBoolean(slot.Available)
+      (slot.Available === undefined || isBoolean(slot.Available))
     ) &&
     isString(data.createdAt) &&
     isString(data.expiresAt)


### PR DESCRIPTION
## 概要
スケジュール作成時にAPIが201を返しているにも関わらず、フロントエンドで「スケジュールの作成に失敗しました」エラーが表示される問題を修正しました。APIレスポンスの型チェックでtimeSlotのidフィールドを必須としていたため、バックエンドの実際のレスポンスと不一致が発生していました。

## 関連Issue
Closes #50

## 変更種別
- [x] 🐛 バグ修正

## 変更内容
### 何を変更したか
- timeSlotのidフィールドを型チェックから除外（runtime-type-check.ts）
- Availableフィールドをオプショナルとして扱うように修正
- TimeSlot型定義にAvailableフィールドを追加

### なぜ変更したか
- バックエンドAPIはtimeSlotにidフィールドを含まないレスポンスを返すため
- フロントエンドの型チェックがこれを必須として扱っていたため、型チェックに失敗していた

---

## 🤖 Claude 自動確認項目
- [x] `make test-all` が成功
- [x] `make lint` が成功
- [x] `make build` が成功
- [x] 関連ドキュメントの更新
- [x] 不要なconsole.log/print文の削除

---

## 動作確認手順
1. `make dev` でローカル環境を起動
2. http://localhost:3000/create にアクセス
3. カレンダーで時間スロットを選択
4. 「作成」ボタンをクリック
5. エラーなくスケジュールが作成され、詳細ページにリダイレクトされることを確認

## スクリーンショット
修正前：APIが201を返しているのに「スケジュールの作成に失敗しました」と表示される
修正後：正常にスケジュールが作成される

## 特に見てほしい箇所
- runtime-type-check.ts の型チェックロジック（L55-60, L78-83）
- TimeSlot型定義へのAvailableフィールド追加（schedule.ts L5）